### PR TITLE
Remove /vagrant paths and assume the module is installed first

### DIFF
--- a/bin/pe_step2_install_remedy_module
+++ b/bin/pe_step2_install_remedy_module
@@ -7,12 +7,6 @@ module="cve20113872"
 
 manifest="$(puppet master --configprint manifest)"
 
-# JJM - REVISIT - This should really be "step 0" (The user gets the module after reading the CVE)
-echo "Installing Puppet CVE-2011-3872 CA Migration Module ..."
-cd /opt/puppet/share/puppet/modules
-puppet-module clean
-puppet-module install /vagrant/modules/${module}/pkg/puppetlabs-${module}-0.0.1.tar.gz --force
-
 if grep -q "include ${module}" "${manifest}"; then
   echo "site.pp already includes class ${module} ... (Nothing to do)"
 else


### PR DESCRIPTION
The behavior without this patch is that step1 assumed it was running
from my personal development location of /vagrant/modules.

We're now going to assume the first thing a customer does is install
this module into their module path.  As a result, we no loner should try
and install the module in step2.  This part of step2 is removed by this
patch.

Furthermore, there is no longer a need to hard code any paths since it's
all either a single script or a puppet manifest itself.
