### PR TITLE
Make cve module self contained and not require stdlib

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description 'This module provides tools to help close the security risk document
 project_page 'http://www.puppetlabs.com'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib', '>= 2.0.0'
+# dependency 'puppetlabs/stdlib', '>= 2.0.0'

--- a/Modulefile
+++ b/Modulefile
@@ -1,11 +1,11 @@
 name    'puppetlabs-cve20113872'
 version '0.0.1'
-source 'git@git.puppetlabs.net:cve20113872.git'
+source 'git@github.com:puppetlabs/puppetlabs-cve20113872.git'
 author 'puppetlabs'
 license 'Apache 2.0'
-summary 'Fix and Remedy CVE-2011-3872'
+summary 'Migration Assistant for CVE-2011-3872'
 description 'This module provides tools to help close the security risk documented in CVE-2011-3872 and migrate a Puppet infrastructure to a new Certificate Authority.'
-project_page 'http://www.puppetlabs.com'
+project_page 'https://github.com/puppetlabs/puppetlabs-cve20113872'
 
 ## Add dependencies, if any:
 # dependency 'puppetlabs/stdlib', '>= 2.0.0'

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,16 @@ This module provides two main pieces of functionality:
  * Help me get secure
  * Once secure, help me migrate to a new CA
 
-# Quick Start (PE) #
+# Quick Start #
+
+This module is designed to be installed from the Forge, but until then:
+
+    cd /tmp
+    git clone git@github.com:puppetlabs/puppetlabs-cve20113872.git cve20113872
+    cd cve20113872
+    rake build
+    cd <modulepath>
+    puppet-module install /tmp/cve20113872/pkg/puppetlabs-cve20113872-0.0.1.tar.gz
 
 ## Install the Module ##
 
@@ -13,9 +22,10 @@ The first step in the remediation process is to install the cve20113872 module
 into your Puppet Master module path.  This will likely be /etc/puppet/modules
 or /etc/puppetlabs/puppet/modules for Puppet Enterprise.
 
-(Note, if the module is not yet on the forge, it may be built from source using
-`puppet-module build`)
+Note, if the module is not yet on the forge, it may be built from source using
+the build task:
 
+    rake build
     cd /etc/puppetlabs/puppet/modules
     puppet-module install /tmp/puppetlabs-cve20113872-0.0.1.tar.gz
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,35 @@
 require 'rake'
-require 'rspec/core/rake_task'
+require 'fileutils'
 
-task :default => [:test]
-
-desc 'Run RSpec'
-RSpec::Core::RakeTask.new(:test) do |t|
-  t.pattern = 'spec/{unit}/**/*.rb'
-  t.rspec_opts = ['--color']
+begin
+  require 'rspec/core/rake_task'
+  HAVE_RSPEC = true
+rescue LoadError
+  HAVE_RSPEC = false
 end
 
-desc 'Generate code coverage'
-RSpec::Core::RakeTask.new(:coverage) do |t|
-  t.rcov = true
-  t.rcov_opts = ['--exclude', 'spec']
+task :default => [:build]
+
+desc "Build Puppet Module Package"
+task :build do
+  system("puppet-module build")
+end
+
+desc "Clean the package directory"
+task :clean do
+  FileUtils.rm_rf("pkg/")
+end
+
+if HAVE_RSPEC then
+  desc 'Run RSpec'
+  RSpec::Core::RakeTask.new(:test) do |t|
+    t.pattern = 'spec/{unit}/**/*.rb'
+    t.rspec_opts = ['--color']
+  end
+
+  desc 'Generate code coverage'
+  RSpec::Core::RakeTask.new(:coverage) do |t|
+    t.rcov = true
+    t.rcov_opts = ['--exclude', 'spec']
+  end
 end

--- a/bin/pe_step1_secure_the_master
+++ b/bin/pe_step1_secure_the_master
@@ -15,29 +15,12 @@ else
   shift
 fi
 
-timestamp="$(ruby -e 'puts Time.now.to_i')"
-
-puppet resource service pe-httpd ensure=stopped hasstatus=true
-
-# As LAK points out, configuring Puppet to communicate with a master
-# using a name that is not in CN or CERTDNSNAMES will secure the
-# entire system again.
-# We need a new certificate to do this...
-old_master_cert="$(puppet master --configprint certname)"
+backup="/etc/puppetlabs/cve20113872.orig.tar.gz"
 
 apachevhost="/etc/puppetlabs/httpd/conf.d/puppetmaster.conf"
-
-confdir="$(puppet master --configprint confdir)"
 ssldir="$(puppet master --configprint ssldir)"
 manifest="$(puppet master --configprint manifest)"
 puppetconf="$(puppet master --configprint config)"
-autosign="${confdir}/autosign.conf"
-hostcrl="$(puppet master --configprint hostcrl)"
-
-# The new CA CN _must_ be different than the old CA CN
-old_ca_cn="$(puppet master --configprint ca_name)"
-
-backup="/etc/puppetlabs/cve20113872.orig.tar.gz"
 
 # Before modifying anything, make a backup
 if [[ -f "${backup}" ]]; then
@@ -55,6 +38,25 @@ else
   tar --files-from "${backup_list}" -czf "${backup}"
   echo "Backup written to: ${backup}" >&2
 fi
+
+timestamp="$(ruby -e 'puts Time.now.to_i')"
+
+# As LAK points out, configuring Puppet to communicate with a master
+# using a name that is not in CN or CERTDNSNAMES will secure the
+# entire system again.
+# We need a new certificate to do this...
+old_master_cert="$(puppet master --configprint certname)"
+
+
+confdir="$(puppet master --configprint confdir)"
+autosign="${confdir}/autosign.conf"
+hostcrl="$(puppet master --configprint hostcrl)"
+
+# The new CA CN _must_ be different than the old CA CN
+old_ca_cn="$(puppet master --configprint ca_name)"
+
+# Stop the Puppet Master service
+puppet resource service pe-httpd ensure=stopped hasstatus=true
 
 # Make sure certdnnames are off.
 idx=0

--- a/lib/puppet/parser/functions/cve20113872_validate_re.rb
+++ b/lib/puppet/parser/functions/cve20113872_validate_re.rb
@@ -1,0 +1,32 @@
+module Puppet::Parser::Functions
+  newfunction(:cve20113872_validate_re, :doc => <<-'ENDHEREDOC') do |args|
+    Perform simple validation of a string against a regular expression.  The second
+    argument of the function should be a string regular expression (without the //'s)
+    or an array of regular expressions.  If none of the regular expressions in the array
+    match the string passed in, then an exception will be raised.
+
+    Example:
+
+    These strings validate against the regular expressions
+
+        cve20113872_validate_re('one', '^one$')
+        cve20113872_validate_re('one', [ '^one', '^two' ])
+
+    These strings do NOT validate
+
+        cve20113872_validate_re('one', [ '^two', '^three' ])
+
+    Jeff McCune <jeff@puppetlabs.com>
+
+    ENDHEREDOC
+    if args.length != 2 then
+      raise Puppet::ParseError, ("cve20113872_validate_re(): wrong number of arguments (#{args.length}; must be 2)")
+    end
+
+    msg = "cve20113872_validate_re(): #{args[0].inspect} does not match #{args[1].inspect}"
+
+    raise Puppet::ParseError, (msg) unless args[1].any? do |re_str|
+      args[0] =~ Regexp.compile(re_str)
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,29 +31,29 @@ class cve20113872 {
   $module = "cve20113872"
 
   # The certificate has /CN=Puppet CA: $hostname
-  validate_re($agent_cert_on_disk_issuer, "^/CN=")
+  cve20113872_validate_re($agent_cert_on_disk_issuer, "^/CN=")
   # pe-puppet or puppet
-  validate_re($agent_user, "puppet")
+  cve20113872_validate_re($agent_user, "puppet")
   # pe-puppet or puppet
-  validate_re($agent_group, "puppet")
+  cve20113872_validate_re($agent_group, "puppet")
   # /etc/puppetlabs/puppet/ssl
-  validate_re($agent_ssldir, '^/')
+  cve20113872_validate_re($agent_ssldir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs
-  validate_re($agent_certdir, '^/')
+  cve20113872_validate_re($agent_certdir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs/ca.pem
-  validate_re($agent_localcacert, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_localcacert, "^/.*?\.pem$")
   # /etc/puppetlabs/puppet/ssl/crl.pem
-  validate_re($agent_hostcrl, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_hostcrl, "^/.*?\.pem$")
   # /var/run/pe-puppet/agent.pid
-  validate_re($agent_pidfile, "^/.*?\.pid$")
+  cve20113872_validate_re($agent_pidfile, "^/.*?\.pid$")
   # Certname can be anything, but it can't be empty.
-  validate_re($agent_certname, ".")
+  cve20113872_validate_re($agent_certname, ".")
   # Agents PID to reload it mid-run
-  validate_re($agent_pid, '^\d+$')
+  cve20113872_validate_re($agent_pid, '^\d+$')
   # Agents vardir.  We'll put scripts in here.
-  validate_re($agent_vardir, '^/')
+  cve20113872_validate_re($agent_vardir, '^/')
   # Agents config file (puppet.conf)
-  validate_re($agent_config, '^/.*/puppet.conf$')
+  cve20113872_validate_re($agent_config, '^/.*/puppet.conf$')
 
   Exec { path => "/opt/puppet/bin:/usr/local/bin:/bin:/usr/bin:/sbin:/usr/sbin:/opt/csw/bin" }
   File {


### PR DESCRIPTION
Without this patch, the cve20113872 module made use of the validate_re()
function from stdlib.  To minimize the number of steps the end user
needs to make this patch copies the function into this module.

This means stdlib is no longer required and the function has been
renamed to prevent conflicts with stdlib should it already be installed
which is the case on PE 1.2.3.

In addition, the README, module metadata and Rakefile have been updated
to reflect this change.  The rake tasks have also been modified to
function if rspec is not installed, which is the case on a PE system.

Finally, a build and clean task have been added to help clean out and
rebuild the cve module packages.
