### PR TITLE
Use sh not bash in the puppet manifests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class cve20113872 {
     }
     exec { "CVE-2011-3872 Disable Revocation":
       command => "${agent_vardir}/${module}/bin/disable_revocation.rb '${agent_config}'",
-      unless  => "bash -c 'puppet agent --configprint certificate_revocation | grep false'",
+      unless  => "sh -c 'puppet agent --configprint certificate_revocation | grep false'",
       before  => Exec["CVE-2011-3872 Reload"],
     }
     exec { "CVE-2011-3872 Reload":


### PR DESCRIPTION
This patch switches the interpreter to sh instead of bash, which should
be more robust on solaris and other operating systems which may not have
bash by default.

Closes #10
