### PR TITLE
Add the cve20113872 class to top scope

### DIFF
--- a/bin/pe_step2_install_remedy_module
+++ b/bin/pe_step2_install_remedy_module
@@ -10,11 +10,11 @@ manifest="$(puppet master --configprint manifest)"
 if grep -q "include ${module}" "${manifest}"; then
   echo "site.pp already includes class ${module} ... (Nothing to do)"
 else
-  echo "Adding ${module} to the default node in site.pp ..."
-  idx=0
-  ruby -p -l -i.backup.${timestamp}.${idx} -e \
-    'gsub(/^(\s*)(node\s+default\s+\{\s*)$/) { "#{$1}#{$2}\n#{$1}  # CVE-2011-3872 CA Migration Class\n#{$1}  include '"${module}"'" }' \
-    "${manifest}"
+  echo "Adding ${module} to the top scope of site.pp ..."
+  echo "" >> "${manifest}"
+  echo "# This class should be removed after the CVE-2011-3872 migration" >> "${manifest}"
+  echo "# process is complete finished" >> "${manifest}"
+  echo "include cve20113872" >> "${manifest}"
 fi
 
 echo "Done ..."


### PR DESCRIPTION
Without this patch the cve20113872 class is added to node default which
may not result in all nodes having the class included in their
configuration catalog.

Based on feedback from Nick F, this patch changes the behavior to
instead add the class to the very top scope of site.pp outside of any
node definition.  This should result in every node having the class
added to its catalog.

Closes #9
