### PR TITLE
Change server setting in puppet.conf even if it's absent

### DIFF
--- a/bin/pe_step2_configure_agents_for_intermediate_dns_name
+++ b/bin/pe_step2_configure_agents_for_intermediate_dns_name
@@ -32,10 +32,28 @@ idx=0
 # Replace the old master name with the new master name.  This reconfigures the
 # agent on the puppet master to use the intermediate DNS name.
 echo -n "Reconfiguring puppet.conf to connect to the master using intermediate dns name ${new_master_cert} ..." >&2
-ruby -p -l -i.backup.${timestamp}.${idx} -e \
-  'gsub(/^(\s*)([^#]*?server.*?=)(\s*)('"${old_master_cert}"')\s*$/) { "#{$1}# Name Fix: #{$4} => '"${new_master_cert}"'\n#{$1}#{$2}#{$3}'"${new_master_cert}"'" }' \
-  "${puppetconf}"
-((idx++))
+# Use genconfig to figure out if server is set in puppet.conf
+if puppet agent --genconfig | grep -q '# server ='; then
+  # server is not in puppet.conf.  If they have a [main], then use that, otherwise add [main]
+  if grep -q '^\[main\]' "${puppetconf}"; then
+    ruby -p -l -i.backup.${timestamp}.${idx} -e \
+      'gsub(/^\[main\].*/) { "[main]\n    server = '"${new_master_cert}"'" }' \
+      "${puppetconf}"
+    ((idx++))
+  else
+    cp -p "${puppetconf}" "${puppetconf}.backup.${timestamp}.${idx}"
+    ((idx++))
+    echo '[main]' >> "${puppetconf}"
+    echo "    server = ${new_master_cert}" >> "${puppetconf}"
+  fi
+else
+  # server is in puppet.conf.  Replace _all_ instances of the server setting in
+  # puppet.conf
+  ruby -p -l -i.backup.${timestamp}.${idx} -e \
+    'gsub(/^(\s*)(server.*?=)(\s*)('"${old_master_cert}"')\s*$/) { "#{$1}server = '"${new_master_cert}"'" }' \
+    "${puppetconf}"
+  ((idx++))
+fi
 echo "done." >&2
 
 # PE configures the fileserver using the old name by default in site.pp  We need to fix this


### PR DESCRIPTION
Without this patch, step2 makes the assumption that the server setting
is present in puppet.conf.  Nigel mentioned we need to take into account
the situation where the customer has removed the server setting and
relies on the default.

This patch takes this into account by using puppet agent --genconfig to
determine if the server setting is at its default value or not.  If it
is, then we look for a [main] section and add the server setting at the
top of the section.  If there is no [main] section then we simply add
one.  This should then work for puppetd and puppet agent.
