### PR TITLE
Add PATH to step3 script

### DIFF
--- a/bin/pe_step3_generate_new_authority
+++ b/bin/pe_step3_generate_new_authority
@@ -3,6 +3,8 @@
 set -e
 set -u
 
+export PATH="/opt/puppet/bin:$PATH"
+
 # Steps:
 # Update puppet.conf
 # Move the existing SSL directory out of the way


### PR DESCRIPTION
The step 3 script does not set the PATH causing failures on PE
installations where the executables have not been made available in
/usr/local/bin or where the executables are not already in the PATH.

This patch explicitly sets PATH to include /opt/puppet/bin first, which
should guarantee the puppet we invoke is the PE puppet on the system.

Closes #29
