### PR TITLE
Issue a new dashboard certificate in step3

### DIFF
--- a/bin/pe_step5_migrate_the_master
+++ b/bin/pe_step5_migrate_the_master
@@ -68,6 +68,54 @@ echo "done." >&2
 cp -p "${ssldir}/ca/ca_crt.pem" "${ssldir}/certs/ca.pem"
 cp -p "${ssldir}/ca/ca_crl.pem" "${ssldir}/crl.pem"
 
+## Dashboard Certificate ##
+#
+# This section should only run if the Puppet Dashboard is installed on the same
+# host as the Puppet Master.  It will issue a new CSR for the dashboard and
+# sign it.  If the dashboard is not on the same host as the Puppet CA, then the
+# normal rake task should be used to re-issue the dashboard certificate.
+#
+# To manually do this process (e.g. if you have Dashboard on a different host.)
+#
+#     # Clean out the existing scripts.
+#     find . -name '*.pem' -print0 | xargs -0 rm
+#     # Generate a new CSR
+#     /opt/puppet/bin/rake cert:create_key_pair
+#     /opt/puppet/bin/rake cert:request
+#     # Sign the certificate request on the master.
+#     puppet cert sign dashboard
+#     # Retrieve the signed certificate
+#     /opt/puppet/bin/rake cert:retrieve
+#     # Fix permissions (If you ran this command as root)
+#     find . -name '*.pem' -print0 | xargs -0 chown puppet-dashboard:puppet-dashboard
+
+: ${DASHBOARD_ROOT:="/opt/puppet/share/puppet-dashboard"}
+if [[ -d "${DASHBOARD_ROOT}/certs" ]]; then
+  for filetype in cert private_key ca_crl public_key ca_cert; do
+    pemfile="${DASHBOARD_ROOT}/certs/dashboard.${filetype}.pem"
+    if [[ -f "${pemfile}" ]]; then
+      cp -p "${pemfile}" "${pemfile}.previous"
+    fi
+  done
+  # Now issue the new certificate
+  echo -n "Issuing new certificate for dashboard..." >&2
+  puppet cert --generate dashboard &>/dev/null
+  # Move the private key into place.  I use a redirection to preserve the owner and permissions
+  # of the original files.
+  cat "${ssldir}/certs/dashboard.pem"        > "${DASHBOARD_ROOT}/certs/dashboard.cert.pem"
+  cat "${ssldir}/private_keys/dashboard.pem" > "${DASHBOARD_ROOT}/certs/dashboard.private_key.pem"
+  cat "${ssldir}/public_keys/dashboard.pem"  > "${DASHBOARD_ROOT}/certs/dashboard.public_key.pem"
+  # Clean up the generated dashboard cert
+  rm  "${ssldir}/certs/dashboard.pem" \
+      "${ssldir}/private_keys/dashboard.pem" \
+      "${ssldir}/public_keys/dashboard.pem"
+  # This is the new certificate only, not the bundle.
+  cat "${ssldir}/certs/ca.pem" > "${DASHBOARD_ROOT}/certs/dashboard.ca_cert.pem"
+  cat "${ssldir}/crl.pem" > "${DASHBOARD_ROOT}/certs/dashboard.ca_crl.pem"
+  echo "done." >&2
+fi
+## End Dashboard Certificate ##
+
 echo -n "Starting Puppet Master..." >&2
 puppet resource service pe-httpd ensure=running hasstatus=true &> /dev/null
 echo "done." >&2


### PR DESCRIPTION
Without this patch the dashboard inventory service and other things that
use the dashboard SSL client certificate no longer work after completing
step 5.  The reason is that the dashboard trusts only the previous CA
and the master trusts only the new CA.  The dashboard needs a client
certificate issued by the new CA.

This patch generates a new dashboard certificate if it detects the
dashboard directory on the same host as the Puppet Master.  It then
copies the private key, certificate, public key, and CA bundles into the
dashboard's certs/ directory.

Closes #33
