### PR TITLE
(#36) Restore the agent's server setting in step 4

### DIFF
--- a/manifests/step4.pp
+++ b/manifests/step4.pp
@@ -110,6 +110,13 @@ class cve20113872::step4 {
         path    => "${agent_hostcrl}",
         content => file("${master_ssldir}/ca/ca_crl.pem"),
       }
+      # Restore the backup of the puppet.conf file if it was created in step2
+      exec { "CVE-2011-3872 Restore puppet.conf":
+        onlyif  => "sh -c \"test -f '${agent_config}.backup.${module}'\"",
+        command => "sh -c \"cp -p '${agent_config}.backup.${module}' '${agent_config}'\"",
+        notify  => Exec["CVE-2011-3872 Reload"],
+        require => File["${agent_config}.backup.${module}"],
+      }
       # Reload the agent.  This is OK to not be idemopotent because we should only
       # add these resources to the catalog if the agent has a certificate issued
       # by an authority the master is not currently using.


### PR DESCRIPTION
As nick points out in #36 the agent still uses the intermediate DNS name
configured in step 2 when it has completed step 4.  At the end of Step
4, the agent possesses a certificate issued by the new CA and only
trusts the new CA.  The server possesses a certificate that works on the
original DNS name.

This patch saves a backup copy of the puppet.conf file before modifying
it in step2 to contain the server = <intermediate dns name> setting.

The patch also updates step4 to restore this file if it exists, thereby
reverting the agent to its original configuration.

In order to avoid step 2 flipping to the intermediate name again after
step 4 flips it back this patch introduces a semaphore file.  The exec
resource that modifies puppet.conf will not run again if step 2 has been
completed with the application of this patch.
