### PR TITLE
Issue/master/37 restore sitepp to original state

### DIFF
--- a/bin/pe_step2_configure_agents_for_intermediate_dns_name
+++ b/bin/pe_step2_configure_agents_for_intermediate_dns_name
@@ -56,6 +56,9 @@ else
 fi
 echo "done." >&2
 
+# Save a backup copy of site.pp to restore in step 5
+cp -p "${manifest}" "${manifest}.original"
+
 # PE configures the fileserver using the old name by default in site.pp  We need to fix this
 echo -n "Reconfiguring site.pp to connect to the master using intermediate DNS name ${new_master_cert} ..." >&2
 ruby -p -l -i.backup.${timestamp}.${idx} -e \

--- a/bin/pe_step5_migrate_the_master
+++ b/bin/pe_step5_migrate_the_master
@@ -26,6 +26,7 @@ apachevhost="/etc/puppetlabs/httpd/conf.d/puppetmaster.conf"
 vardir="$(puppet master --configprint vardir)"
 ssldir="$(puppet master --configprint ssldir)"
 certname="$(puppet master --configprint certname)"
+manifest="$(puppet master --configprint manifest)"
 
 # This is some shell magic to read a file into a variable if the
 # variable isn't already set.
@@ -116,6 +117,10 @@ if [[ -d "${DASHBOARD_ROOT}/certs" ]]; then
 fi
 ## End Dashboard Certificate ##
 
+## Restore site.pp to the original state when we started this process ##
+cp -p "${manifest}.original" "${manifest}"
+rm "${manifest}.original"
+
 echo -n "Starting Puppet Master..." >&2
 puppet resource service pe-httpd ensure=running hasstatus=true &> /dev/null
 echo "done." >&2
@@ -123,7 +128,11 @@ echo "done." >&2
 cat <<EOMESSAGE
 
 The puppet master has been issued an SSL certificate by the new CA.  The
-migration to the new CA is now complete.  Puppet agents which have been migrated
-should now be able to reconnect to this master.
+migration to the new CA is now complete.  Puppet agents which have been
+migrated should now be able to reconnect to this master.
+
+The manifest ${manifest} has been restored to its
+original state.  The cve20113872::step2 and cve20113872::step4 classes will no
+longer be included in node catalogs.
 
 EOMESSAGE

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,11 +17,11 @@ class cve20113872 {
   # /etc/puppetlabs/puppet/ssl/certs
   cve20113872_validate_re($agent_certdir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs/ca.pem
-  cve20113872_validate_re($agent_localcacert, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_localcacert, '^/.*?\.pem$')
   # /etc/puppetlabs/puppet/ssl/crl.pem
-  cve20113872_validate_re($agent_hostcrl, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_hostcrl, '^/.*?\.pem$')
   # /var/run/pe-puppet/agent.pid
-  cve20113872_validate_re($agent_pidfile, "^/.*?\.pid$")
+  cve20113872_validate_re($agent_pidfile, '^/.*?\.pid$')
   # Certname can be anything, but it can't be empty.
   cve20113872_validate_re($agent_certname, ".")
   # Agents PID to reload it mid-run

--- a/manifests/step4.pp
+++ b/manifests/step4.pp
@@ -32,7 +32,7 @@ class cve20113872::step4 {
   $module = "cve20113872"
 
   # The certificate has /CN=Puppet CA: $hostname
-  cve20113872_validate_re($agent_cert_on_disk_issuer, "^/CN=")
+  cve20113872_validate_re($agent_cert_on_disk_issuer, '^/CN=')
   # pe-puppet or puppet
   cve20113872_validate_re($agent_user, "puppet")
   # pe-puppet or puppet
@@ -42,11 +42,11 @@ class cve20113872::step4 {
   # /etc/puppetlabs/puppet/ssl/certs
   cve20113872_validate_re($agent_certdir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs/ca.pem
-  cve20113872_validate_re($agent_localcacert, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_localcacert, '^/.*?\.pem$')
   # /etc/puppetlabs/puppet/ssl/crl.pem
-  cve20113872_validate_re($agent_hostcrl, "^/.*?\.pem$")
+  cve20113872_validate_re($agent_hostcrl, '^/.*?\.pem$')
   # /var/run/pe-puppet/agent.pid
-  cve20113872_validate_re($agent_pidfile, "^/.*?\.pid$")
+  cve20113872_validate_re($agent_pidfile, '^/.*?\.pid$')
   # Certname can be anything, but it can't be empty.
   cve20113872_validate_re($agent_certname, ".")
   # Agents PID to reload it mid-run


### PR DESCRIPTION
commit e9c36d228dcf2d113bcbcf69e4203189c9798b34
Author: Jeff McCune jeff@puppetlabs.com
Date:   Fri Oct 21 09:38:48 2011 -0700

```
(#37) Restore site.pp to original state in step5

As Nick points out in #37, we should make a best effort to restore the
configuration catalogs of all the nodes to their original state before
starting the remedy process.

Without this patch, site.pp would still include the cve20113872::step2
and cve20113872::step4 classes in the top scope of the manifests.

This patch addresses the problem by saving an original copy of site.pp
in step2 before making any modifications.  This has the effect to
rolling the filebucket server setting back if it's set and removing the
cve20113872 classes.

Closes #37
```

commit 1cbcd029a5589721a9acd463e0cadcfb303ae1de
Author: Jeff McCune jeff@puppetlabs.com
Date:   Fri Oct 21 09:42:52 2011 -0700

```
(#24) Fix unrecognized escape sequences

Nigel points out in #24 the functions validating the values of the
custom facts this module uses throw warnings into the system log.  These
look like:

    warning: Unrecognised escape sequence '\.' in file
    /etc/puppetlabs/puppet/modules/cve20113872/manifests/init.pp at line 44
    warning: Unrecognised escape sequence '\.' in file
    /etc/puppetlabs/puppet/modules/cve20113872/manifests/init.pp at line 46
    warning: Unrecognised escape sequence '\.' in file
    /etc/puppetlabs/puppet/modules/cve20113872/manifests/init.pp at line 48

The problem is that the code uses double quotes which causes the Puppet
parser to perform string escaping before passing the string to the
underlying function.

This patch fixes the problem by converting the validation functions to
string literals, thus avoiding the string escapes and allowing the
underlying regular expression parser to handle the escape sequences
properly.

Closes #24
```
