### PR TITLE
Fix tight puppet user group validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,10 +8,10 @@ class cve20113872 {
 
   # The certificate has /CN=Puppet CA: $hostname
   cve20113872_validate_re($agent_cert_on_disk_issuer, "^/CN=")
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_user, "puppet")
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_group, "puppet")
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_user, '^\w')
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_group, '^\w')
   # /etc/puppetlabs/puppet/ssl
   cve20113872_validate_re($agent_ssldir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs

--- a/manifests/step2.pp
+++ b/manifests/step2.pp
@@ -26,10 +26,10 @@
 class cve20113872::step2 {
   $module = "cve20113872"
 
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_user, "puppet")
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_group, "puppet")
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_user, '^\w')
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_group, '^\w')
   # Agents vardir.  We'll put scripts in here.
   cve20113872_validate_re($agent_vardir, '^/')
   # Agent config file

--- a/manifests/step4.pp
+++ b/manifests/step4.pp
@@ -33,10 +33,10 @@ class cve20113872::step4 {
 
   # The certificate has /CN=Puppet CA: $hostname
   cve20113872_validate_re($agent_cert_on_disk_issuer, '^/CN=')
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_user, "puppet")
-  # pe-puppet or puppet
-  cve20113872_validate_re($agent_group, "puppet")
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_user, '^\w')
+  # pe-puppet or puppet, but only check for a leading word character
+  cve20113872_validate_re($agent_group, '^\w')
   # /etc/puppetlabs/puppet/ssl
   cve20113872_validate_re($agent_ssldir, '^/')
   # /etc/puppetlabs/puppet/ssl/certs


### PR DESCRIPTION
Nigel pointed out in [1] that the regular expression validation for the
puppet user and the puppet group was too tight.  We support things other
than puppet and pe-puppet.

This patch relaxes the validation to ensure the string has a leading
word character and nothing else.  This will defend against an empty
string, which will be the most common problem and prevent false positive
failures with things like "root'

[1] https://github.com/puppetlabs/puppetlabs-cve20113872/blob/master/manifests/step2.pp#L30
