### PR TITLE
Tighten the logic preventing step4 from applying to a master

### DIFF
--- a/lib/facter/fact_is_migration_host.rb
+++ b/lib/facter/fact_is_migration_host.rb
@@ -1,0 +1,23 @@
+require 'facter/util/with_puppet'
+
+# This fact's value will only be available when running with facter --puppet
+# Or when loaded inside of Puppet.  Otherwise, it will be nil
+# 'true' if the dns_name exists in /var/opt/lib/pe-puppet/cve20113872/
+# (PE) This file is written in step 1 of the cve20113872 migration
+# module.  'false' otherwise.  This provides the three states we need.
+# Absolutely yes (true), absolutely no (false), and we have no idea (nil).
+module Facter
+  class IsMigrationHost
+    # Provides the with_puppet method
+    extend Facter::Util::WithPuppet
+    def self.add_facts
+      with_puppet do
+        Facter.add(:is_migration_host) do
+          setcode { File.exists? File.join(Puppet[:vardir], "cve20113872", "dns_name") }
+        end
+      end
+    end
+  end
+end
+
+Facter::IsMigrationHost.add_facts

--- a/lib/facter/util/with_puppet.rb
+++ b/lib/facter/util/with_puppet.rb
@@ -10,7 +10,7 @@ module Facter::Util::WithPuppet
         # Facter.warnonce "Could not load facts for #{Puppet[:hostcert]}: #{detail}"
       end
     else
-      "Puppet is not loaded.  Didn't do anything... :("
+      nil
     end
   end
 end


### PR DESCRIPTION
Nigel points out in [1] the logic protecting the puppet master from
receiving the resources in step 4 is not as robust as it could be.  If
the PE facts are disabled for some reason or removed, then the resources
would still be applied to the puppet master.

This patch fixes the problem by explicitly checking of the
fact_is_puppetmaster fact is "false"  If the fact is removed, then this
logic will still protect the puppet master.

An agent will no longer receive the resources if their facts have been
tampered with however.  This will need to be verified on PE 1.1 and
earlier versions which may not have this fact.

[1] https://github.com/puppetlabs/puppetlabs-cve20113872/blob/master/manifests/step4.pp#L80
