### PR TITLE
(#31) Fix no such file error with check_progress

### DIFF
--- a/bin/check_progress
+++ b/bin/check_progress
@@ -40,6 +40,7 @@ module CVE20113872
     def load_active_nodes
       now = Time.now
       dir = Pathname.new(File.join(yamldir, "node"))
+      return unless File.directory?(dir)
       Dir.chdir(dir.to_s)
       # Select files modified within the last 30 days
       files = dir.entries.select do |f|
@@ -58,6 +59,7 @@ module CVE20113872
     # the active nodes
     def load_node_progress
       dir = Pathname.new(File.join(yamldir, "cve20113872"))
+      return unless File.directory?(dir)
       Dir.chdir(dir.to_s)
       # Select files modified within the last 30 days
       files = dir.entries.select do |f|


### PR DESCRIPTION
Without this patch applied there is a problem when the check progress
script runs before any nodes have received a catalog from Step 2 or Step
4.  The directory containing node information does not yet exist.

This patch fixes the problem by returning from the method loading this
information if the directory does not exist.

The error this patch fixes is:

```
/etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:61:in `chdir': No such file or directory - /var/opt/lib/pe-puppet/yaml/cve20113872 (Errno::ENOENT)
        from /etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:61:in `load_node_progress'
        from /etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:104:in `reload'
        from /etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:108:in `run'
        from /etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:127:in `main'
        from /etc/puppetlabs/puppet/modules/cve20113872/bin/check_progress:134
```
