### PR TITLE
(#31) Add total count of nodes remedied

### DIFF
--- a/bin/check_progress
+++ b/bin/check_progress
@@ -140,6 +140,13 @@ module CVE20113872
         bucket_totals.keys.sort.each do |bucket|
           puts "    %40s %6d (%3.1f%%)" % [ "#{bucket}:", bucket_totals[bucket], bucket_totals[bucket] * 100 / step_totals['total'] ]
         end
+        # Get a total of "Risk Mitigated" buckets
+        mitigated_count = bucket_totals.reduce(0) do |mitigated, (bucket, bucket_count)|
+          mitigated += bucket_count if bucket =~ /Risk Mitigated/
+          mitigated
+        end
+        puts "    --------------------------------------------------------"
+        puts "    %40s %6d (%3.1f%%)" % [ "Total of Nodes Remediated:", mitigated_count, mitigated_count * 100 / step_totals['total'] ]
         puts
       end
     end


### PR DESCRIPTION
This patch adds a sum total count and percentage of the nodes remedied
by the migration process.  This information does not exist without this
patch, the individual mitigation counts would need to be summed up.

Nigel asked for this addition.  The new output looks like:

```
tatus as of: 2011-10-23 16:49:53

                                Total Nodes:      4 *
                       Step 0 (Has not run):      0 (0.0%)
                        Step 2 (DNS Switch):      0 (0.0%)
                        Step 4 (SSL Switch):      4 (100.0%)

 * Total of the nodes active within the last 30 days

         Risk Mitigated (Issued a new Cert):      4 (100.0%)
    --------------------------------------------------------
                  Total of Nodes Remediated:      4 (100.0%)
```

Closes #31
