### PR TITLE
Fix quoting in PATH on remedy scripts

### DIFF
--- a/bin/pe_step1_enable_intermediate_dns_name
+++ b/bin/pe_step1_enable_intermediate_dns_name
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-export PATH="${CVE_PATH:-'/opt/puppet/bin'}:$PATH"
+export PATH="/opt/puppet/bin:$PATH"
 
 # The intermediate certificate name is a required argument
 if [[ -z "${1:-}" ]]; then

--- a/bin/pe_step2_configure_agents_for_intermediate_dns_name
+++ b/bin/pe_step2_configure_agents_for_intermediate_dns_name
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-export PATH="${CVE_PATH:-'/opt/puppet/bin'}:$PATH"
+export PATH="/opt/puppet/bin:$PATH"
 module="cve20113872"
 class="${module}::step2"
 

--- a/bin/pe_step3_generate_new_authority
+++ b/bin/pe_step3_generate_new_authority
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-export PATH="${CVE_PATH:-'/opt/puppet/bin'}:$PATH"
+export PATH="/opt/puppet/bin:$PATH"
 
 # Steps:
 # Update puppet.conf

--- a/bin/pe_step4_migrate_agents_to_new_authority
+++ b/bin/pe_step4_migrate_agents_to_new_authority
@@ -6,7 +6,7 @@
 set -e
 set -u
 
-export PATH="${CVE_PATH:-'/opt/puppet/bin'}:$PATH"
+export PATH="/opt/puppet/bin:$PATH"
 module="cve20113872"
 class="${module}::step4"
 

--- a/bin/pe_step5_migrate_the_master
+++ b/bin/pe_step5_migrate_the_master
@@ -3,7 +3,7 @@
 set -e
 set -u
 
-export PATH="${CVE_PATH:-'/opt/puppet/bin'}:$PATH"
+export PATH="/opt/puppet/bin:$PATH"
 
 # Steps
 # * Stop the master


### PR DESCRIPTION
The single quotes in the CVE_PATH environment variable are causing
potential issues and not placing the PE ruby in the path as expected.

This patch fixes the issue by explicitly unshifting /opt/puppet/bin to
the PATH variable in the pe step scripts.
