### PR TITLE
Fix premature remediation exit on idx increment

### DIFF
--- a/bin/pe_step1_enable_intermediate_dns_name
+++ b/bin/pe_step1_enable_intermediate_dns_name
@@ -89,9 +89,13 @@ else
   echo "Backup written to: ${backup}" >&2
 fi
 
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
+
 # Make sure certdnsnames are off.  This will prevent the master from issuing
 # additional agent certificates that may be used to impersonate the master.
-idx=0
 echo -n "Making sure certdnsnames are turned off (${puppetconf}) ..." >&2
 ruby -p -l -i.backup.${timestamp}.${idx} -e \
   'gsub(/^(\s*)(certdnsnames\b.*$)/) { "#{$1}# Disabled to mitigate CVE-2011-3872\n#{$1}# #{$2}" }' \

--- a/bin/pe_step2_configure_agents_for_intermediate_dns_name
+++ b/bin/pe_step2_configure_agents_for_intermediate_dns_name
@@ -27,7 +27,10 @@ puppetconf="$(puppet master --configprint config)"
 manifest="$(puppet master --configprint manifest)"
 old_master_cert="$(puppet master --configprint certname)"
 
-idx=0
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # Replace the old master name with the new master name.  This reconfigures the
 # agent on the puppet master to use the intermediate DNS name.

--- a/bin/pe_step3_generate_new_authority
+++ b/bin/pe_step3_generate_new_authority
@@ -22,7 +22,11 @@ old_ca_cn="$(puppet master --configprint ca_name)"
 
 apachevhost="/etc/puppetlabs/httpd/conf.d/puppetmaster.conf"
 timestamp="$(ruby -e 'puts Time.now.to_i')"
-idx=0
+
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # This is some shell magic to read a file into a variable if the
 # variable isn't already set.

--- a/bin/pe_step4_migrate_agents_to_new_authority
+++ b/bin/pe_step4_migrate_agents_to_new_authority
@@ -13,7 +13,11 @@ class="${module}::step4"
 manifest="$(puppet master --configprint manifest)"
 
 timestamp="$(ruby -e 'puts Time.now.to_i')"
-idx=0
+
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # Add the cve20113872::step4 class to the catalog of every node.  This catalog
 # will cause the agent to move its ssldir out of the way and submit a new CSR

--- a/bin/webrick/webrick_step1_enable_intermediate_dns_name
+++ b/bin/webrick/webrick_step1_enable_intermediate_dns_name
@@ -69,9 +69,13 @@ else
   echo "Backup written to: ${backup}" >&2
 fi
 
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
+
 # Make sure certdnsnames are off.  This will prevent the master from issuing
 # additional agent certificates that may be used to impersonate the master.
-idx=0
 echo -n "Making sure certdnsnames are turned off (${puppetconf}) ..." >&2
 ruby -p -l -i.backup.${timestamp}.${idx} -e \
   'gsub(/^(\s*)(certdnsnames\b.*$)/) { "#{$1}# Disabled to mitigate CVE-2011-3872\n#{$1}# #{$2}" }' \

--- a/bin/webrick/webrick_step2_configure_agents_for_intermediate_dns_name
+++ b/bin/webrick/webrick_step2_configure_agents_for_intermediate_dns_name
@@ -32,7 +32,10 @@ puppetconf="$(puppet master --configprint config)"
 manifest="$(puppet master --configprint manifest)"
 old_master_cert="$(puppet master --configprint certname)"
 
-idx=0
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # Replace the old master name with the new master name.  This reconfigures the
 # agent on the puppet master to use the intermediate DNS name.

--- a/bin/webrick/webrick_step3_generate_new_authority
+++ b/bin/webrick/webrick_step3_generate_new_authority
@@ -27,7 +27,11 @@ certname="$(puppet master --configprint certname)"
 old_ca_cn="$(puppet master --configprint ca_name)"
 
 timestamp="$(ruby -e 'puts Time.now.to_i')"
-idx=0
+
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # This is some shell magic to read a file into a variable if the
 # variable isn't already set.

--- a/bin/webrick/webrick_step4_migrate_agents_to_new_authority
+++ b/bin/webrick/webrick_step4_migrate_agents_to_new_authority
@@ -10,7 +10,10 @@ class="${module}::step4"
 manifest="$(puppet master --configprint manifest)"
 
 timestamp="$(ruby -e 'puts Time.now.to_i')"
-idx=0
+# If this starts at 0, incrementing it will exit nonzero
+# See: https://gist.github.com/1310371
+# and https://github.com/puppetlabs/puppetlabs-cve20113872/issues/69
+idx=1
 
 # Add the cve20113872::step4 class to the catalog of every node.  This catalog
 # will cause the agent to move its ssldir out of the way and submit a new CSR


### PR DESCRIPTION
There is an issue where Lucid systems do not treat set -e the same as
CentOS systems when running the remediation process shell scripts.

In particular, incrementing a variable in bash from 0 to 1 will always
return an exit code ($?) of 1 even though it increments the variable
properly.  However, on CentOS 5.5. systems set -e ignores this "failure"
while debian based systems appear to treat the non-zero exit code as
grounds to abort the script via set -e.

This patch starts all idx index variables at "1" to avoid this issue.
When incrementing from any non-zero positive integer the proper exit
code of 0 is returned.

Closes #69
