### PR TITLE
(#52) Fix step 5 assumption of --certdnsnames

### DIFF
--- a/bin/pe_step5_migrate_the_master
+++ b/bin/pe_step5_migrate_the_master
@@ -44,9 +44,20 @@ if [[ -z "${DNS_ALT_NAMES}" ]]; then
   exit 1
 fi
 
+# Figure out if we've been patched or not.
+if puppet master --configprint dns_alt_names &>/dev/null; then
+  HAVE_PATCHED='true'
+  alt_names_option="dns_alt_names"
+  alt_names_separator=","
+else
+  HAVE_PATCHED='false'
+  alt_names_option="certdnsnames"
+  alt_names_separator=":"
+fi
+
 # This is disabled at this point in puppet.conf, so we have to read it from what
 # we wrote out in step1
-certdnsnames="${DNS_ALT_NAMES}"
+alt_names_value="${DNS_ALT_NAMES}"
 intermediate_name="${DNS_NAME}"
 
 echo -n "Stopping Puppet Master..." >&2
@@ -58,7 +69,7 @@ for d in certs private_keys public_keys ca/signed; do
   mv "${ssldir}/${d}/${certname}.pem" "${ssldir}/${d}/${certname}.pem.previous"
 done
 # Now issue the new certificate
-puppet cert --generate --certdnsnames "${certdnsnames}" "${certname}" >/dev/null
+puppet cert --generate "--${alt_names_option}" "${alt_names_value}" "${certname}" >/dev/null
 echo "done." >&2
 
 # Replace the certificate bundles which authenticate the previous ca with a

--- a/bin/webrick/webrick_step1_enable_intermediate_dns_name
+++ b/bin/webrick/webrick_step1_enable_intermediate_dns_name
@@ -13,6 +13,18 @@ else
   shift
 fi
 
+# Check if the master has been upgraded to a patched Puppet Version
+# We don't support this yet.
+if puppet master --configprint dns_alt_names &>/dev/null; then
+  echo "PENDING: It appears puppet on this node has already been upgraded to a version which" >&2
+  echo "Closes the CVE-2011-3872 vulnerability.  Nodes may still be vulnerable and their certificates" >&2
+  echo "re-issued, however this program has not been patched to support the --dns_alt_names option" >&2
+  echo "introduced in fixed versions of Puppet." >&2
+  echo "" >&2
+  echo "Please see https://github.com/puppetlabs/puppetlabs-cve20113872/issues/71 for up to date information" >&2
+  exit 2
+fi
+
 # Check if the master is running.
 if [[ -f $(puppet master --configprint pidfile) ]]; then
   echo "You must stop your Webrick puppet master before running this script" >&2


### PR DESCRIPTION
Without this patch, the patches added for #52 are not complete.  Step 5 still
calls `puppet cert --certdnsnames` without checking if PE has been upgraded to
the fixed version that ignores this option.

This patch updates the step 5 scripts to correct generate a puppet master
certificate using the --dns_alt_names option if the puppet master has already
been patched.

This fix does not add --dns_alt_names to the webrick (FOSS) scripts, but
it does add a defense mechanism in step1.  Issue #71 has been filed to
support --dns_alt_names in the FOSS remediation process.  The defense
mechanism introduced in this patch should be removed once issue #71 is
addressed.

Closes #52
